### PR TITLE
Support for dynamic allocation

### DIFF
--- a/joblibspark/backend.py
+++ b/joblibspark/backend.py
@@ -91,7 +91,7 @@ class SparkDistributedBackend(ParallelBackendBase, AutoBatchingMixin):
             n_jobs = max_num_concurrent_tasks
         if n_jobs > max_num_concurrent_tasks:
             warnings.warn("User-specified n_jobs ({n}) is greater than the max number of "
-                          "concurrent tasks (c) this cluster can run now. If dynamic "
+                          "concurrent tasks ({c}) this cluster can run now. If dynamic "
                           "allocation is enabled for the cluster, you might see more "
                           "executors allocated."
                           .format(n=n_jobs, c=max_num_concurrent_tasks))

--- a/joblibspark/backend.py
+++ b/joblibspark/backend.py
@@ -90,10 +90,10 @@ class SparkDistributedBackend(ParallelBackendBase, AutoBatchingMixin):
             # n_jobs=-1 means requesting all available workers
             n_jobs = max_num_concurrent_tasks
         if n_jobs > max_num_concurrent_tasks:
-            warnings.warn("User-specified n_jobs ({n}) is greater than "
-                          "max_num_concurrent_tasks ({c}), "
-                          "if spark executor use dynamic allocation mode, "
-                          "more executors will be allocated."
+            warnings.warn("User-specified n_jobs ({n}) is greater than the max number of "
+                          "concurrent tasks (c) this cluster can run now. If dynamic "
+                          "allocation is enabled for the cluster, you might see more "
+                          "executors allocated."
                           .format(n=n_jobs, c=max_num_concurrent_tasks))
         return n_jobs
 

--- a/joblibspark/backend.py
+++ b/joblibspark/backend.py
@@ -90,8 +90,11 @@ class SparkDistributedBackend(ParallelBackendBase, AutoBatchingMixin):
             # n_jobs=-1 means requesting all available workers
             n_jobs = max_num_concurrent_tasks
         if n_jobs > max_num_concurrent_tasks:
-            n_jobs = max_num_concurrent_tasks
-            warnings.warn("limit n_jobs to be maxNumConcurrentTasks in spark: " + str(n_jobs))
+            warnings.warn("User-specified n_jobs ({n}) is greater than "
+                          "max_num_concurrent_tasks ({c}), "
+                          "if spark executor use dynamic allocation mode, "
+                          "more executors will be allocated."
+                          .format(n=n_jobs, c=max_num_concurrent_tasks))
         return n_jobs
 
     def _get_max_num_concurrent_tasks(self):

--- a/test/test_backend.py
+++ b/test/test_backend.py
@@ -16,5 +16,5 @@ def test_effective_n_jobs():
 
     with warnings.catch_warnings(record=True) as w:
         warnings.simplefilter("always")
-        assert backend.effective_n_jobs(n_jobs=16) == 8
+        assert backend.effective_n_jobs(n_jobs=16) == 16
         assert len(w) == 1


### PR DESCRIPTION
Support for dynamic allocation, always set the thread pool size to n_jobs but throws a warning if current spark.maxNumConcurrenttaks is smaller than n_jobs.