### PR TITLE
Only use pinned thread mode in Spark 3.2 when explicitly enabled

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,9 +4,18 @@ jobs:
   build:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
-        PIP_PYSPARK: [ 'pyspark==3.0.1', 'pyspark==3.1.2', 'https://dist.apache.org/repos/dist/dev/spark/v3.2.0-rc2-bin/pyspark-3.2.0.tar.gz' ]
-    name: Run test on ${{ matrix.PIP_PYSPARK }}
+        include:
+          - PIP_PYSPARK: 'pyspark==3.0.1'
+            PIN_MODE: false
+          - PIP_PYSPARK: 'pyspark==3.1.2'
+            PIN_MODE: false
+          - PIP_PYSPARK: 'pyspark==3.2.0'
+            PIN_MODE: false
+          - PIP_PYSPARK: 'pyspark==3.2.0'
+            PIN_MODE: true
+    name: Run test on ${{ matrix.PIP_PYSPARK }}, pin_mode=${{ matrix.PIN_MODE }}
     steps:
       - uses: actions/checkout@v2
       - name: Setup python
@@ -23,4 +32,4 @@ jobs:
           ./run-pylint.sh
       - name: Run test suites
         run: |
-          ./run-tests.sh
+          PYSPARK_PIN_THREAD=${{ matrix.PIN_MODE }} ./run-tests.sh

--- a/joblibspark/backend.py
+++ b/joblibspark/backend.py
@@ -142,6 +142,7 @@ class SparkDistributedBackend(ParallelBackendBase, AutoBatchingMixin):
         # See joblib.parallel.Parallel._dispatch
 
         def run_on_worker_and_fetch_result():
+            # TODO: handle possible spark exception here. # pylint: disable=fixme
             worker_rdd = self._spark.sparkContext.parallelize([0], 1)
             mapper_fn = lambda _: cloudpickle.dumps(func())
             if self._spark_supports_job_cancelling:

--- a/joblibspark/backend.py
+++ b/joblibspark/backend.py
@@ -168,11 +168,13 @@ class SparkDistributedBackend(ParallelBackendBase, AutoBatchingMixin):
 
             return cloudpickle.loads(ser_res)
 
-        if self._spark_pinned_threads_enabled:
+        try:
             # pylint: disable=no-name-in-module,import-outside-toplevel
             from pyspark import inheritable_thread_target
             run_on_worker_and_fetch_result = \
                 inheritable_thread_target(run_on_worker_and_fetch_result)
+        except ImportError:
+            pass
 
         return self._get_pool().apply_async(
             SafeFunction(run_on_worker_and_fetch_result),

--- a/joblibspark/backend.py
+++ b/joblibspark/backend.py
@@ -49,6 +49,7 @@ def register():
     register_parallel_backend('spark', SparkDistributedBackend)
 
 
+# pylint: disable=too-many-instance-attributes
 class SparkDistributedBackend(ParallelBackendBase, AutoBatchingMixin):
     """A ParallelBackend which will execute all batches on spark.
 
@@ -96,11 +97,10 @@ class SparkDistributedBackend(ParallelBackendBase, AutoBatchingMixin):
             # n_jobs=-1 means requesting all available workers
             n_jobs = max_num_concurrent_tasks
         if n_jobs > max_num_concurrent_tasks:
-            warnings.warn("User-specified n_jobs ({n}) is greater than the max number of "
-                          "concurrent tasks ({c}) this cluster can run now. If dynamic "
-                          "allocation is enabled for the cluster, you might see more "
-                          "executors allocated."
-                          .format(n=n_jobs, c=max_num_concurrent_tasks))
+            warnings.warn(f"User-specified n_jobs ({n_jobs}) is greater than the max number of "
+                          f"concurrent tasks ({max_num_concurrent_tasks}) this cluster can run now."
+                          "If dynamic allocation is enabled for the cluster, you might see more "
+                          "executors allocated.")
         return n_jobs
 
     def _get_max_num_concurrent_tasks(self):


### PR DESCRIPTION
Only use pinned thread mode in Spark 3.2 when explicitly enabled
Signed-off-by: Weichen Xu <weichen.xu@databricks.com>
