### PR TITLE
Close ThreadPool at exit

### DIFF
--- a/joblibspark/backend.py
+++ b/joblibspark/backend.py
@@ -17,6 +17,7 @@
 """
 The joblib spark backend implementation.
 """
+import atexit
 import warnings
 from multiprocessing.pool import ThreadPool
 import uuid
@@ -142,6 +143,7 @@ class SparkDistributedBackend(ParallelBackendBase, AutoBatchingMixin):
         """
         if self._pool is None:
             self._pool = ThreadPool(self._n_jobs)
+            atexit.register(self._pool.close)
         return self._pool
 
     def start_call(self):

--- a/joblibspark/backend.py
+++ b/joblibspark/backend.py
@@ -168,7 +168,8 @@ class SparkDistributedBackend(ParallelBackendBase, AutoBatchingMixin):
 
             # TODO: handle possible spark exception here. # pylint: disable=fixme
             worker_rdd = self._spark.sparkContext.parallelize([0], 1)
-            mapper_fn = lambda _: cloudpickle.dumps(func())
+            def mapper_fn(_):
+                return cloudpickle.dumps(func())
             if self._spark_supports_job_cancelling:
                 if self._spark_pinned_threads_enabled:
                     self._spark.sparkContext.setLocalProperty(


### PR DESCRIPTION
Signed-off-by: Li Jiang <bnujli@gmail.com>

Sometimes I met below Exception:
```
Exception ignored in: <function Pool.__del__ at 0x7f62ad3bd8b0>
Traceback (most recent call last):
  File "/home/x/anaconda3/envs/syml-py38/lib/python3.8/multiprocessing/pool.py", line 268, in __del__
    self._change_notifier.put(None)
  File "/home/x/anaconda3/envs/syml-py38/lib/python3.8/multiprocessing/queues.py", line 368, in put
    self._writer.send_bytes(obj)
  File "/home/x/anaconda3/envs/syml-py38/lib/python3.8/multiprocessing/connection.py", line 200, in send_bytes
    self._send_bytes(m[offset:offset + size])
  File "/home/x/anaconda3/envs/syml-py38/lib/python3.8/multiprocessing/connection.py", line 411, in _send_bytes
    self._send(header + buf)
  File "/home/x/anaconda3/envs/syml-py38/lib/python3.8/multiprocessing/connection.py", line 368, in _send
    n = write(self._handle, buf)
OSError: [Errno 9] Bad file descriptor
```

when running code
```python
with parallel_backend("spark"):
    with Parallel(n_jobs=num_executors, verbose=verbose) as parallel:
       ...
        results = parallel(
            delayed(evaluation_function)(trial_to_run.config)
            for trial_to_run in trials_to_run
        )
      ...
```

And I found this similar [issue](https://github.com/dask/dask/issues/5806) of Dask, it was fixed by this [PR](https://github.com/dask/dask/pull/5852). So I tried it in my case, the exception gone!

Therefore, I'd like to raise this PR for fixing the issue of joblib-spark.

Thanks.
