### PR TITLE
Fixed LooseVersion warning, added more tests, updated workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,27 +6,26 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - PIP_PYSPARK: 'pyspark==3.0.1'
-            PIN_MODE: false
-          - PIP_PYSPARK: 'pyspark==3.1.2'
-            PIN_MODE: false
-          - PIP_PYSPARK: 'pyspark==3.2.0'
-            PIN_MODE: false
-          - PIP_PYSPARK: 'pyspark==3.2.0'
+        PYTHON_VERSION: ["3.7", "3.8", "3.9", "3.10"]
+        PIN_MODE: [false, true]
+        PYSPARK_VERSION: ["3.0.3", "3.1.3", "3.2.3", "3.3.1"]
+        exclude:
+          - PYSPARK_VERSION: "3.0.3"
             PIN_MODE: true
-    name: Run test on ${{ matrix.PIP_PYSPARK }}, pin_mode=${{ matrix.PIN_MODE }}
+          - PYSPARK_VERSION: "3.1.3"
+            PIN_MODE: true
+    name: Run test on pyspark ${{ matrix.PYSPARK_VERSION }}, pin_mode ${{ matrix.PIN_MODE }}, python ${{ matrix.PYTHON_VERSION }}
     steps:
-      - uses: actions/checkout@v2
-      - name: Setup python
-        uses: actions/setup-python@v2
+      - uses: actions/checkout@v3
+      - name: Setup python ${{ matrix.PYTHON_VERSION }}
+        uses: actions/setup-python@v4
         with:
-          python-version: '3.7'
+          python-version: ${{ matrix.PYTHON_VERSION }}
           architecture: x64
       - name: Install python packages
         run: |
-          pip install joblib==0.14.0 scikit-learn==0.23.1 pytest pylint
-          pip install ${{ matrix.PIP_PYSPARK }}
+          pip install joblib>=0.14.0 scikit-learn>=0.23.1 pytest pylint
+          pip install pyspark==${{ matrix.PYSPARK_VERSION }}
       - name: Run pylint
         run: |
           ./run-pylint.sh

--- a/joblibspark/backend.py
+++ b/joblibspark/backend.py
@@ -21,7 +21,7 @@ import atexit
 import warnings
 from multiprocessing.pool import ThreadPool
 import uuid
-from distutils.version import LooseVersion
+from packaging.version import Version, parse
 
 from joblib.parallel \
     import AutoBatchingMixin, ParallelBackendBase, register_parallel_backend, SequentialBackend
@@ -41,7 +41,7 @@ def register():
     """
     try:
         import sklearn  # pylint: disable=C0415
-        if LooseVersion(sklearn.__version__) < LooseVersion('0.21'):
+        if parse(sklearn.__version__) < Version('0.21'):
             warnings.warn("Your sklearn version is < 0.21, but joblib-spark only support "
                           "sklearn >=0.21 . You can upgrade sklearn to version >= 0.21 to "
                           "make sklearn use spark backend.")

--- a/test/test_spark.py
+++ b/test/test_spark.py
@@ -16,10 +16,10 @@
 #
 from time import sleep
 import pytest
-from distutils.version import LooseVersion
+from packaging.version import Version, parse
 import sklearn
 
-if LooseVersion(sklearn.__version__) < LooseVersion('0.21'):
+if parse(sklearn.__version__) < Version('0.21'):
     raise RuntimeError("Test requires sklearn version >=0.21")
 else:
     from joblib.parallel import Parallel, delayed, parallel_backend


### PR DESCRIPTION
- fixed LooseVersion warning
- added tests for python 3.8~3.10 and pyspark 3.3.1
- updated workflow action versions


Signed-off-by: Li Jiang <bnujli@gmail.com>